### PR TITLE
updated getAvailablePath() to prevent improper rename of duplicate files

### DIFF
--- a/src/main/scala/net/wiringbits/myphototimeline/FileOrganizerService.scala
+++ b/src/main/scala/net/wiringbits/myphototimeline/FileOrganizerService.scala
@@ -67,8 +67,20 @@ class FileOrganizerService(metadataService: MetadataService)(implicit logger: Si
 
   @tailrec
   private def getAvailablePath(parent: os.Path, name: String, suffix: Int = 0): os.Path = {
-    val actualName = if (suffix == 0) name else s"${name}_($suffix)"
-    val path = parent / actualName
+    var path = parent
+    if (suffix == 0) {
+      path = path / name
+    } else {
+      val i = name.lastIndexOf('.')
+      if (i > 0) {
+        val ext = name.substring(i)
+        val fileNoExt = name.substring(0, i)
+        val actualName = s"${fileNoExt}_($suffix)$ext"
+        path = path / actualName
+      } else {
+        path = path / name
+      }
+    }
 
     if (os.exists(path)) {
       getAvailablePath(parent, name, suffix + 1)

--- a/src/main/scala/net/wiringbits/myphototimeline/FileOrganizerService.scala
+++ b/src/main/scala/net/wiringbits/myphototimeline/FileOrganizerService.scala
@@ -55,35 +55,23 @@ class FileOrganizerService(metadataService: MetadataService)(implicit logger: Si
     val monthNumber = createdOn.getMonthValue
     val month = "%2d-%s".format(monthNumber, monthName).replace(" ", "0")
     val parent = destinationDirectory / year / month
-    val destinationFile = getAvailablePath(parent, sourceFile.last)
+    val destinationFile = getAvailablePath(parent, sourceFile.baseName, sourceFile.ext)
     os.move(sourceFile, destinationFile, replaceExisting = false, createFolders = true)
     destinationFile.toIO.setLastModified(createdOn.toEpochDay)
   }
 
   def safeMove(destinationDirectory: os.Path, sourceFile: os.Path): Unit = {
-    val destinationFile = getAvailablePath(destinationDirectory, sourceFile.last)
+    val destinationFile = getAvailablePath(destinationDirectory, sourceFile.baseName, sourceFile.ext)
     os.move(sourceFile, destinationFile, replaceExisting = false, createFolders = true)
   }
 
   @tailrec
-  private def getAvailablePath(parent: os.Path, name: String, suffix: Int = 0): os.Path = {
-    var path = parent
-    if (suffix == 0) {
-      path = path / name
-    } else {
-      val i = name.lastIndexOf('.')
-      if (i > 0) {
-        val ext = name.substring(i)
-        val fileNoExt = name.substring(0, i)
-        val actualName = s"${fileNoExt}_($suffix)$ext"
-        path = path / actualName
-      } else {
-        path = path / name
-      }
-    }
-
+  private def getAvailablePath(parent: os.Path, baseName: String, ext: String, suffix: Int = 0): os.Path = {
+    val actualName = if (suffix == 0) s"${baseName}.${ext}" else s"${baseName}_($suffix).${ext}"
+    val path = parent / actualName
+    
     if (os.exists(path)) {
-      getAvailablePath(parent, name, suffix + 1)
+      getAvailablePath(parent, baseName, ext, suffix + 1)
     } else {
       path
     }


### PR DESCRIPTION
Fixed issue #9 : Logic was added to the getAvailablePath function to ensure that renamed files always end with the file extension and not the added suffix.